### PR TITLE
Use just the -m3g, will this work on smaller instances?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ EXPOSE 8983
 WORKDIR /opt/solr
 VOLUME /opt/solr/server/solr/dc-collection/data
 
-CMD ["/bin/bash", "-c", "/opt/solr/bin/solr -Xms1g -Xmx3g -f"]
+CMD ["/bin/bash", "-c", "/opt/solr/bin/solr -m3g -f"]


### PR DESCRIPTION
The stage & pre-prod instances don't have 3 gig of memory, will this
work on them. If not, need to set SOLR_JAVA_MEM var
Can't use Java -X params directly on the solr script