### PR TITLE
quick fix to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ ENV SOLR_HEAP="3g"
 WORKDIR /opt/
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
-  apt-get update && \
+  echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" \
+    > /etc/apt/sources.list.d/jessie-backports.list && \
+  sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list && \
+  apt-get -o Acquire::Check-Valid-Until=false update && \
   apt-get -y install bzip2 awscli &&\
   wget -nv --output-document=/opt/$SOLR.tgz http://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/$SOLR.tgz && \ 
   tar -xvf $SOLR.tgz && \


### PR DESCRIPTION
as per https://unix.stackexchange.com/a/508948 -- this is a quick fix
to work around the fact that as of March 20, 2019

"Wheezy and Jessie have been integrated into the archive.debian.org
structure recently, we are now removing all of Wheezy and all non-LTS
architectures of Jessie from the mirror network starting today."

https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html